### PR TITLE
Update README.md to solve "How to get unique identifier from telegram api" problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Getting started with [Telegram Bot API](https://core.telegram.org/bots/api).
 How to get unique identifier from telegram api:
 
 ```bash
-curl https://api.telegram.org/bot<token>/getUpdates
+curl https://api.telegram.org/bot<Token>/getMe
 ```
 
 See the result: (get chat id like `65382999`)


### PR DESCRIPTION
hi,
to get the id of the bot chat, the old endpoint wasn't showing the result. so to correct this issue the new endpoint is fixing this problem.
you can refer to https://core.telegram.org/bots/api API documentation which explains that.

regards,