### PR TITLE
ci: add regression test for step output interpolation (#68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,28 @@ jobs:
           token: ${{ secrets.TELEGRAM_TOKEN }}
           message_file: tests/message.txt
 
+      # Regression test for issue #68: step outputs written to $GITHUB_OUTPUT
+      # must be usable inside the message input. The step producing the
+      # output needs an `id` so it can be referenced via steps.<id>.outputs.
+      - name: set step output
+        id: repo-discussion
+        run: |
+          COUNT=42
+          echo "discussionCount=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: verify step output is interpolated
+        run: |
+          test "${{ steps.repo-discussion.outputs.discussionCount }}" = "42"
+
+      - name: send message with step output (issue #68)
+        uses: ./
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          message: |
+            There are currently ${{ steps.repo-discussion.outputs.discussionCount }} discussions, come on!
+          format: markdown
+
       # - name: send message using socks5 proxy URL
       #   uses: appleboy/telegram-action@master
       #   with:


### PR DESCRIPTION
## Summary

Add a CI regression test that reproduces the exact scenario reported in issue #68: a step writes a value to `$GITHUB_OUTPUT`, a follow-up step asserts the runner interpolates `${{ steps.<id>.outputs.<name> }}` correctly, and the value is then sent through the `message` input with `format: markdown`.

This proves the reported scenario works end to end. Expression interpolation happens in the GitHub Actions runner **before** the action container starts, so the action only ever receives the final string — the "not work" symptom in #68 is caused by workflow configuration on the caller side (most commonly a missing `id:` on the step that writes the output, or an output produced in a different job without a `jobs.<id>.outputs` mapping), not by telegram-action.

Verified green on run [31923863537](https://github.com/appleboy/telegram-action/actions/runs/31923863537):

- `verify step output is interpolated` executed `test "42" = "42"` — the expression was expanded by the runner.
- The action received `message: There are currently 42 discussions, come on!` and the Telegram message was delivered successfully.

## Related issues

- Jira: N/A
- GitHub/Gitea: Related to #68

## Architecture / flow

```mermaid
flowchart TD
    A["set step output<br/>(id: repo-discussion)<br/>echo discussionCount=42 >> $GITHUB_OUTPUT"] --> B["verify step output is interpolated<br/>test '42' = '42'"]
    B --> C["send message with step output<br/>uses: ./ with message containing<br/>steps.repo-discussion.outputs.discussionCount"]
    style A fill:#d4edda,stroke:#28a745
    style B fill:#d4edda,stroke:#28a745
    style C fill:#d4edda,stroke:#28a745
```

## AI authorship

- [ ] No AI was used
- [x] AI was used
  - **Tool / model**: Claude Code (Claude Fable 5)
  - **AI-authored files**: `.github/workflows/ci.yml` (new test steps)
  - **Human line-by-line reviewed**: None — not yet reviewed by a human.

## Change classification

- [x] Leaf change
- [ ] Core change

CI-only test addition; no action code, inputs, or published image are touched.

## Plan reference

Prove issue #68's scenario (`$GITHUB_OUTPUT` step output used in the `message` input) works, as a permanent regression test in CI.

## Verification

- **Automated**: Full `telegram message` workflow ran green on this branch — run [31923863537](https://github.com/appleboy/telegram-action/actions/runs/31923863537). The new steps interpolated the output and delivered the Telegram message.
- **Manual**: Inspected run logs confirming `test "42" = "42"` and `message: There are currently 42 discussions, come on!`.
- **Not run**: N/A

## Security check

- [x] No secrets in the diff
- [ ] External inputs are validated
- [ ] Permission checks are tested
- [ ] Errors do not leak internals
- [x] N/A - no external or security-sensitive interface changed

## Risk and rollback

- **Risk**: Minimal — adds three CI steps to the existing `build` job; worst case is a CI failure on this workflow.
- **Rollback**: Revert the single commit (`git revert 6544097`).

## Reviewer guide

- **Read carefully**: The three new steps in `.github/workflows/ci.yml` (`set step output`, `verify step output is interpolated`, `send message with step output`).
- **Spot-check**: Nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
